### PR TITLE
Re-add CNAME

### DIFF
--- a/.github/CNAME
+++ b/.github/CNAME
@@ -1,0 +1,1 @@
+elementnet.js.org


### PR DESCRIPTION
Was removed, but I no longer use travis publishing, so I need to add it back.

<!--
Thank you for your contribution!
Please don't forget to see the contributing guide before sending a pull request.
-->
